### PR TITLE
Remove NodeJS 7 from travis CI target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
 language: node_js
 node_js:
   - '6'
-  - '7'
   - stable
 
 cache:


### PR DESCRIPTION
Reduce build footprint by keeping only Node 6 and latest stable version as build target.